### PR TITLE
Refactor chart for new config methods

### DIFF
--- a/stable/pomerium/templates/authenticate-deployment.yaml
+++ b/stable/pomerium/templates/authenticate-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $configName := default (include "pomerium.fullname" .) .Values.config.existingConfig }}
 {{- $secretName := default (include "pomerium.fullname" .) .Values.config.existingSecret }}
 apiVersion: apps/v1
 kind: Deployment
@@ -21,8 +22,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
       annotations:
+        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -42,6 +44,9 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+{{- if or .Values.config.existingConfig .Values.config.policy }}
+          - --config=/etc/pomerium/config.yaml
+{{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -118,6 +123,15 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
+{{- if or .Values.config.existingConfig .Values.config.policy }}
+        volumeMounts:
+        - mountPath: /etc/pomerium/
+          name: config
+      volumes:
+      - name: config
+        configMap:
+          name: {{ $configName }}
+{{- end }}
       resources:
 {{ toYaml .Values.resources | indent 10 }}
 {{- if .Values.extraVolumes }}

--- a/stable/pomerium/templates/authorize-deployment.yaml
+++ b/stable/pomerium/templates/authorize-deployment.yaml
@@ -22,8 +22,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
       annotations:
+        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -43,6 +44,9 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+{{- if or .Values.config.existingConfig .Values.config.policy }}
+          - --config=/etc/pomerium/config.yaml
+{{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -58,14 +62,6 @@ spec:
             secretKeyRef:
               name: {{ $secretName }}
               key: shared-secret
-{{- if or .Values.config.existingConfig .Values.config.policyFile}}
-        - name: POLICY_FILE
-          value: /etc/pomerium/policy.yaml
-{{- end }}
-{{- if .Values.config.policy}}
-        - name: POLICY
-          value: {{ .Values.config.policy }}
-{{- end }}
         - name: CERTIFICATE
           valueFrom:
             secretKeyRef:
@@ -99,12 +95,12 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
-{{- if or .Values.config.existingConfig .Values.config.policyFile}}
+{{- if or .Values.config.existingConfig .Values.config.policy }}
         volumeMounts:
         - mountPath: /etc/pomerium/
-          name: policy
+          name: config
       volumes:
-      - name: policy
+      - name: config
         configMap:
           name: {{ $configName }}
 {{- end }}

--- a/stable/pomerium/templates/configmap.yaml
+++ b/stable/pomerium/templates/configmap.yaml
@@ -9,5 +9,18 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 data:
-  policy.yaml: {{toYaml .Values.config.policyFile | indent 4}}
+{{- if and .Values.config.existingPolicy .Values.config.extraOpts }}
+{{ fail "Cannot use config.extraOpts with config.existingPolicy" }}
+{{- end }}
+{{- if and .Values.config.existingPolicy .Values.config.policy }}
+{{ fail "Cannot use config.policy with config.existingPolicy" }}
+{{- end }}
+  config.yaml: 
+{{- if .Values.config.extraOpts }}
+{{ toYaml .Values.config.extraOpts | indent 4 -}}
+{{- end }}
+{{- if .Values.config.policy -}}
+    policy: 
+{{ toYaml .Values.config.policy | indent 6 }}
+{{- end }}
 {{- end }}

--- a/stable/pomerium/templates/proxy-deployment.yaml
+++ b/stable/pomerium/templates/proxy-deployment.yaml
@@ -22,8 +22,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
       annotations:
+        config/checksum: {{ print .Values.config.extraOpts | sha256sum }}
+{{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -43,6 +44,9 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
+{{- if or .Values.config.existingConfig .Values.config.policy }}
+          - --config=/etc/pomerium/config.yaml
+{{- end }}
 {{- range $key, $value := .Values.extraArgs }}
 {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -71,14 +75,6 @@ spec:
           value: {{ default (printf "%s.%s.svc.cluster.local" (include "pomerium.authenticate.fullname" .) .Release.Namespace ) .Values.proxy.authenticateInternalUrl}}
         - name: AUTHORIZE_INTERNAL_URL
           value: {{ default (printf "%s.%s.svc.cluster.local" (include "pomerium.authorize.fullname" .) .Release.Namespace ) .Values.proxy.authorizeInternalUrl}}
-{{- if or .Values.config.existingConfig .Values.config.policyFile}}
-        - name: POLICY_FILE
-          value: /etc/pomerium/policy.yaml
-{{- end }}
-{{- if .Values.config.policy}}
-        - name: POLICY
-          value: {{ .Values.config.policy }}
-{{- end }}
         - name: CERTIFICATE
           valueFrom:
             secretKeyRef:
@@ -112,12 +108,12 @@ spec:
             path: /ping
             port: https
             scheme: HTTPS
-{{- if or .Values.config.existingConfig .Values.config.policyFile}}
+{{- if or .Values.config.existingConfig .Values.config.policy }}
         volumeMounts:
         - mountPath: /etc/pomerium/
-          name: policy
+          name: config
       volumes:
-      - name: policy
+      - name: config
         configMap:
           name: {{ $configName }}
 {{- end }}

--- a/stable/pomerium/values.yaml
+++ b/stable/pomerium/values.yaml
@@ -10,26 +10,29 @@ config:
   sharedSecret: ""
   cookieSecret: ""
   generateTLS: true
-  policyFile: |-
-    - from: httpbin.corp.pomerium.io
-      to: http://httpbin
-      allowed_domains:
-      - pomerium.io
-    - from: external-httpbin.corp.pomerium.io
-      to: httpbin.org
-      allowed_domains:
-      - gmail.com
-    - from: weirdlyssl.corp.pomerium.io
-      to: http://neverssl.com
-      allowed_users:
-      - bdd@pomerium.io
-      allowed_groups:
-      - admins
-      - developers
-    - from: hello.corp.pomerium.io
-      to: http://hello:8080
-      allowed_groups:
-      - admins
+  extraOpts: {}
+  existingPolicy: ""
+  policy: {}
+  # policy:
+  #   - from: httpbin.corp.pomerium.io
+  #     to: http://httpbin
+  #     allowed_domains:
+  #     - pomerium.io
+  #   - from: external-httpbin.corp.pomerium.io
+  #     to: httpbin.org
+  #     allowed_domains:
+  #     - gmail.com
+  #   - from: weirdlyssl.corp.pomerium.io
+  #     to: http://neverssl.com
+  #     allowed_users:
+  #     - bdd@pomerium.io
+  #     allowed_groups:
+  #     - admins
+  #     - developers
+  #   - from: hello.corp.pomerium.io
+  #     to: http://hello:8080
+  #     allowed_groups:
+  #     - admins
 
 authenticate:
   # fullnameOverride: authenticate


### PR DESCRIPTION
#### What this PR does / why we need it:

Proposal for handling https://github.com/pomerium/pomerium/issues/115

I can make this formally against upstream when we're ready.  Since our helm chart is in limbo right now, I just wanted to put a solution out there to work off of and finalize.

Thoughts behind this approach:

- Allow as much configuration to be present in config file as possible to leverage hot reloading at a later date
- Try to retain as much of existing interface as possible
- Eliminate policyFile support
  - config.policy populates the config CM.  
  - external policy can be sourced via config.existingPolicy
  - a policy env var can still be present via extraEnv
- Support sourcing external policy or entire configurations
- Restart containers when non-policy section of configMap changes

Non-goal: full update for v0.0.4.  I know there are some changes but I haven't had time to track them down.  